### PR TITLE
Containerize the application 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.gitignore

--- a/Dockerfile-angular
+++ b/Dockerfile-angular
@@ -46,5 +46,6 @@ EXPOSE 4200
 
 # Start
 
-ENTRYPOINT [ "ng", "serve"]
-
+#ENTRYPOINT  ["ng", "serve", "--host 0.0.0.0"]
+#ENTRYPOINT  ng serve --host 0.0.0.0
+CMD ng serve --host 0.0.0.0 

--- a/Dockerfile-angular
+++ b/Dockerfile-angular
@@ -49,3 +49,4 @@ EXPOSE 4200
 #ENTRYPOINT  ["ng", "serve", "--host 0.0.0.0"]
 #ENTRYPOINT  ng serve --host 0.0.0.0
 CMD ng serve --host 0.0.0.0 
+LABEL status=current

--- a/Dockerfile-angular
+++ b/Dockerfile-angular
@@ -1,4 +1,4 @@
-# Dcokerfile - Docker build script for Pollex
+# Dcokerfile - Docker build script for pollex-angular
 #
 #    Copyright (c) 2019 - Open Source Competencer Center ICMC-USP
 #
@@ -21,33 +21,30 @@
 
 FROM ubuntu:19.10
 FROM python:3.7
+FROM node:12.13.1
 
 # Application home directory
 
-RUN mkdir /home/pollex
-
 WORKDIR /home/pollex
-
-# We need Flask framework (there's currently no official Docker image)
-
-RUN pip install flask
 
 # Copy application files into the image
 
-COPY run.py .
-COPY app app/
-COPY config config/
-COPY instance instance/
+COPY pollex-angular/ ./pollex-angular
+COPY frontend/ ./frontend
 
-# By default, the container will listen to port 5000 internally
+WORKDIR pollex-angular
 
-EXPOSE 5000
+# Seteup angular
 
-# Start WSGI application
+RUN npm install
+RUN npm install -g @angular/cli
+RUN npm install -g jquery@1.9.1 --save
 
-ENV FLASK_APP=run.py
-ENV FLASK_ENV=development
+# By default, the container will listen to port 4200 internally
 
-ENTRYPOINT ["python"]
-CMD ["run.py"]
-LABEL status="current"
+EXPOSE 4200
+
+# Start
+
+ENTRYPOINT [ "ng", "serve"]
+

--- a/Dockerfile-flask
+++ b/Dockerfile-flask
@@ -21,21 +21,18 @@
 
 FROM ubuntu:19.10
 FROM python:3.7
-#FROM node:12.13.1
 
 # Application home directory
 
-RUN mkdir /home/pollex
-
 WORKDIR /home/pollex
 
-# We need Flask framework (there's currently no official Docker image)
+# We need Flask framework 
 
 RUN pip install flask
 
 # Copy application files into the image
 
-COPY pollex-flask .
+COPY pollex-flask ./pollex-flask
 
 # By default, the container will listen to port 5000 internally
 
@@ -46,6 +43,6 @@ EXPOSE 5000
 ENV FLASK_APP=run.py
 ENV FLASK_ENV=development
 
-ENTRYPOINT ["python"]
-CMD ["run.py"]
-LABEL status="current"
+WORKDIR pollex-flask
+
+ENTRYPOINT ["python", "run.py"]

--- a/Dockerfile-flask
+++ b/Dockerfile-flask
@@ -46,3 +46,4 @@ ENV FLASK_ENV=development
 WORKDIR pollex-flask
 
 ENTRYPOINT ["python", "run.py"]
+LABEL status=current

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,18 @@
+
+ Pollex INSTALL GUIDE
+ ------------------------------
+
+ ESSENTIAL INFORMATION
+
+ Pollex implementation follows a service-oriented architecture approach.
+ It is designed as a collection of web servers which interact by means of
+ a REST API. To thand end, Pollex currently uses Docker container framework.
+
+ QUICK DIRECTIONS
+
+ The software is built from the main project directory by using the
+ provided 'make' script. Please, refer to Makefile for available
+ build rules.
+
+
+ 

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,29 @@
 # Currently, the project uses Docker as the RPS.
 # Available build targets:
 #
-#   all:	builds RP image (Docker image)
-#   start:	bring up RP instance (Docker container)
-#   stop:	gring down RP instance
-#   login:      login into a running RP instance
-#   clean:	remove temporary files
-#   cleanup:    cleans and remove RP image
+#   all:		build the docker images
+#
+#   image_flask: 	builds flask image
+#   image_angular:	builds angular image
+#   images:		built both images
+#
+#   start_flask:	starts flask container
+#   start_angular:	starts angular_container
+#   start:	        starts both containers
+#
+#   stop_flask:		stop flask container
+#   stop angular:       stop angular_container
+#   stop:		stop both containers
+#
+#   list:		lists application's containers and images
+#
+#   login_flask:	log into a running flask container (bash prompt)
+#   login_angular:	log into a running angular container (bash prompt)
+#
+#                           call 'exit' from the prompt to log out.
+#
+#   clean:		remove temporary files from work directory (as usual)
+#   cleanup:    	remove both flask's and angular's containers and images
 
 # User configs (defaults)
 
@@ -64,6 +81,10 @@ instance/config.py:
 	$(MAKE) -C polex-flask
 
 # Build RP image
+
+image_flask : $(FLASK_IMAGE)
+
+image_angular: $(ANGULAR_IMAGE)
 
 images : $(FLASK_IMAGE) $(ANGULAR_IMAGE)
 	@$(DOCKER) image prune -f --filter "label=status=current"	
@@ -103,7 +124,7 @@ stop_angular:
 	@echo "Container stopped and removed"
 
 
-.PHONY: start stop start_flask stop_flask start_angular stop_angular clean cleanup
+.PHONY: start stop start_flask stop_flask start_angular stop_angular clean cleanup image_flask image_angular images
 
 # Clean temporary files
 

--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,11 @@ image_angular: $(ANGULAR_IMAGE)
 images : $(FLASK_IMAGE) $(ANGULAR_IMAGE)
 	@$(DOCKER) image prune -f --filter "label=status=current"	
 
-
-$(FLASK_IMAGE) : $(FLASK_DOCKERFILE) $(sources-flask:%=pollex-flask/%)
+$(FLASK_IMAGE) : clean_dangling $(FLASK_DOCKERFILE) $(sources-flask:%=pollex-flask/%)
 	$(DOCKER) build -f $(FLASK_DOCKERFILE) -t $(FLASK_IMAGE) .
-	@echo "Removing dangling previous version image"
 
 
-$(ANGULAR_IMAGE) : $(ANGULAR_DOCKERFILE) $(sources-angular:%=pollex-angular/%)
+$(ANGULAR_IMAGE) : clean_dangling $(ANGULAR_DOCKERFILE) $(sources-angular:%=pollex-angular/%)
 	$(DOCKER) build -f $(ANGULAR_DOCKERFILE) -t $(ANGULAR_IMAGE) .
 	@echo "Removing dangling previous version image"
 
@@ -124,7 +122,7 @@ stop_angular:
 	@echo "Container stopped and removed"
 
 
-.PHONY: start stop start_flask stop_flask start_angular stop_angular clean cleanup image_flask image_angular images
+.PHONY: start stop start_flask stop_flask start_angular stop_angular clean cleanup image_flask image_angular images clean_dangling
 
 # Clean temporary files
 
@@ -137,6 +135,11 @@ cleanup:
 	$(MAKE) stop
 	$(DOCKER) rmi -f $(FLASK_IMAGE) $(ANGULAR_IMAGE)
 	$(MAKE) clean
+
+clean_dangling:
+	@echo "Removing dangling previous version image"
+	@$(DOCKER) image prune -f --filter "label=status=current"	
+
 
 # List items
 

--- a/README
+++ b/README
@@ -1,0 +1,97 @@
+
+
+  POLLEX - An open source application for conducing online polls.
+  ---------------------------------------------------------------
+
+  Copyright (c) 2019 - Open Source Competence Center at ICMC
+  This is free source software distributed under the terms of GNU GPL vr.3
+
+
+
+         _
+        | \        
+        | |___
+  _____/  (___)    Pollex: (from Latin 'pollex'), thumb.
+ |o|     (_____)
+ |_|____  (____)   A thumbs-up tool for collaborative teams.
+        \_(___)   
+
+  
+
+  Essentials
+  ------------------------------
+
+  Pollex is an tool to support online communities to reach consensus
+
+  on opinions, preferences and joint decisions.
+
+  You may want to use Pollex to carrying out online polls to
+
+  chose an option from among a finite set of predefined alternatives or to
+
+  inform their availability for scheduling an event in a range or dates.
+
+  Beyond the capabilities of some alternative tools, Pollex allows  flexible
+
+  customization of pools rules and decision criteria such as
+
+     * making a single choice between mutually exclusive alternatives;
+  
+     * choosing one or more options between a set of possible choices;
+
+     * expressing relative preferences between a list of options;
+
+  Also, the poll policy and decision criteria may be chosen from different
+
+  available formats to meet the team needs. For instance it may 
+
+     * allow or not partial results to be known during the poll;
+
+     * allow or not participants to change votes before the poll ends;
+
+     * votes to be either secret or publicly visible by other participants
+
+     * poll to end either after a deadline or when a majority is reached.
+
+
+  Project development notes
+  ------------------------------
+
+  Pollex was originally developed as a didactic project in an undergraduate
+  course on Open Source Systems for Computer Science / Engineering students
+  at University of Sao Paulo, with support of the ICMC Open Source Competence
+  Center (CCOS).
+
+  All developers mentioned in the file AUTHORS are acknowledged.
+
+  The latest release of Pollex may be found at the project repository
+  https://github.com/flossschool/pollex
+
+  IMPORTANT: The software is still in alpha stage and not all of the
+  	     aforementioned feature may be already available.
+
+  You are more than welcome to contribute to further development of Pollex.
+
+  Installing the software
+  ------------------------------
+
+        
+
+    For directions on building and installing Pollex, please
+    refer to file INSTALL.
+
+  Contributing to the project
+  ------------------------------
+
+    If you would be so kind as to contributing to _Pollex_ with either code,
+    bug reports, suggestions or general feedback, please, start by reading
+    the developer documentation at doc/developer
+    
+  Copyright and licensing
+  ------------------------------
+
+   For author, copyright and licensing information please refer to the
+   respective files AUTHORS and LICENSE.
+
+
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
  Pollex is a web-based application for conducing online polls.
 ```
 
-*Pollex* was originally developed as a didactic project in undergraduate course on Open Source Systems for Computer Science / Engineering students at University of São Paulo, with support of the ICMC Open Source Competence Center.
+*Pollex* was originally developed as a didactic project in an undergraduate course on Open Source Systems for Computer Science / Engineering students at University of São Paulo, with support of the ICMC Open Source Competence Center.
 
 ## Quick start
 
@@ -27,7 +27,7 @@
 
 - **Contributing to the project**
 
-    If you would be so kind as to contributing to _Pollex_ with either code, bug reports, suggestions and general feedback, please, start by reading the developer documentation at `doc/developer`
+    If you would be so kind as to contributing to _Pollex_ with either code, bug reports, suggestions or general feedback, please, start by reading the developer documentation at `doc/developer`
     
 - **Copyright and license information**
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 *Pollex* was originally developed as a didactic project in an undergraduate course on Open Source Systems for Computer Science / Engineering students at University of São Paulo, with support of the ICMC Open Source Competence Center.
 
+As of today, the project is still under alpha release.
+
 ## Quick start
 
 - **Features and general information**

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@
     
 - **Copyright and license information**
 
-   For author, copyprig and licensing information please refer to the respective files `AHTORS` and `COPYING`.
+   For author, copyprig and licensing information please refer to the respective files `AHTORS` and `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
-# Pollex
+# Pollex - An online poll application with extras
 
-  An Open Source online poll application
 ```
         _
        | \        
@@ -13,3 +12,23 @@
  
  Pollex is a web-based application for conducing online polls.
 ```
+
+*Pollex* was originally developed as a didactic project in undergraduate course on Open Source Systems for Computer Science / Engineering students at University of São Paulo, with support of the ICMC Open Source Competence Center.
+
+## Quick start
+
+- **Features and general information**
+   
+   For general overview and essential information, please refer to the text file `README`. 
+
+- **Inatalling the softwrare**
+
+    For directions on building and installing _Pollex_, please refer to file `INSTALL`.
+
+- **Contributing to the project**
+
+    If you would be so kind as to contributing to _Pollex_ with either code, bug reports, suggestions and general feedback, please, start by reading the developer documentation at `doc/developer`
+    
+- **Copyright and license information**
+
+   For author, copyprig and licensing information please refer to the respective files `AHTORS` and `COPYING`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |_|____  (____)   A thumbs-up tool for collaborative teams.
        \_(___)   
  
- Pollex is a web-based application for conducing online polls.
+ Pollex is an open source application for conducing online polls.
 ```
 
 *Pollex* was originally developed as a didactic project in an undergraduate course on Open Source Systems for Computer Science / Engineering students at University of São Paulo, with support of the ICMC Open Source Competence Center.
@@ -23,7 +23,7 @@ As of today, the project is still under alpha release.
    
    For general overview and essential information, please refer to the text file `README`. 
 
-- **Inatalling the softwrare**
+- **Installing the software**
 
     For directions on building and installing _Pollex_, please refer to file `INSTALL`.
 
@@ -33,4 +33,4 @@ As of today, the project is still under alpha release.
     
 - **Copyright and license information**
 
-   For author, copyprig and licensing information please refer to the respective files `AHTORS` and `LICENSE`.
+   For author, copyright and licensing information please refer to the respective files `AUTHORS` and `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 
-# pollex
+# Pollex
 
   An Open Source online poll application
+```
+        _
+       | \        
+       | |___
+ _____/  (___)    Pollex: (from Latin 'pollex'), thumb.
+|o|     (_____)
+|_|____  (____)   A thumbs-up tool for collaborative teams.
+       \_(___)   
+ 
+ Pollex is a web-based application for conducing online polls.
+```

--- a/pollex-angular/Makefile
+++ b/pollex-angular/Makefile
@@ -1,4 +1,4 @@
-# Makefile - Build script for pollex-flask
+# Makefile - Build script for pollex-angular
 #
 #    Copyright (c) 2019 - Open Source Competencer Center ICMC-USP
 #
@@ -18,11 +18,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-all : instance/config.py
-
-instance/config.py:
-	install -d instance
-	touch instance/config.py
+all : 
 
 .PHONY: clean
 


### PR DESCRIPTION
An attempt to containerize the application.
Top source directory's Makefile can be use to build and start two containers

- one will contain `pollex-flask`
- another will contain `pollex-angular` and `frontend`

Angular container listen to external port 8080. Both container listens to each other at the default ports.
See `Makefile` header for available rules to build, start etc. the containers.

Top directory's `README`  contains a brief Pollex wish list with the features we would like to see.

Would you please review or reassign it for test and eventually merging to develop?